### PR TITLE
Make the Date(int days) constructor and Days property public

### DIFF
--- a/NDate/Date.cs
+++ b/NDate/Date.cs
@@ -44,11 +44,13 @@ namespace NDate
         public Date(Date date) : this(date._days) { }
         public Date(int year, int month, int day) : this(new DateTime(year, month, day)) { }
 
-        Date(int days)
+        public Date(int days)
         {
             if (days < 0 || days > MaxDays) throw new ArgumentOutOfRangeException(nameof(days));
             _days = days;
         }
+            
+        public int TotalDays => _days;
 
         public static Date Today => new Date(DateTime.Today);
 


### PR DESCRIPTION
Using integer value for days starting from 0000 year is a good basis for many communication methods, such as network protocols.

This change would allow people to transfer the Date as a simple `int` value and recreate the Date object with it on the other end.

The `TimeSpan`, for example, has the public constructor for its fundametal "ticks" property. As well as the `TotalTicks` one.